### PR TITLE
plugin tested up to latest version of WordPress!

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: sanzeeb3
 Tags: pwa, offline, alert
 Requires at least: 4.0
-Tested up to: 5.8
+Tested up to: 6.1
 Requires PHP: 5.3
 Stable tag: 1.4.3
 License: GPLv3


### PR DESCRIPTION
internet-connection-status plugin has been tested up to WordPress 6.1 version. It's working perfectly fine.
Screenshot:
![image](https://user-images.githubusercontent.com/69840558/202139578-5d38d77b-e676-4dc1-bbc7-384c5bef6787.png)
